### PR TITLE
Add input to skip labeling already labeled issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Automatically adds or removes labels from issues. You define the labels you'd li
 
 To add it to your workflow:
 
-```
+```yml
     - uses: andymckay/labeler@1.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -12,8 +12,8 @@ To add it to your workflow:
 
 This adds the `needs-triage` and `bug` labels to the issue. The most common approach is to do this when issues are created, you can do this with the following in your workflow file:
 
-```
-on: 
+```yml
+on:
   issues:
     types: [opened]
 ```
@@ -22,7 +22,7 @@ The parameter `ignore-if-assigned` checks at the time of the action running if t
 
 This action can also be used to remove labels from an issue. Just pass the label(s) to be removed separated by commas.
 
-```
+```yml
     - uses: andymckay/labeler@1.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -32,7 +32,7 @@ This action can also be used to remove labels from an issue. Just pass the label
 
 An example use-case would be, to remove the `help-wanted` label when an issue is assigned to someone. For this, the workflow file would look like:
 
-```
+```yml
 on:
   issues:
     types: [assigned]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ This action can also be used to remove labels from an issue. Just pass the label
 
 ```yml
     - uses: andymckay/labeler@1.0.2
-    - uses: andymckay/labeler@1.0.2
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         remove-labels: "help-wanted"

--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,8 @@ inputs:
   ignore-if-assigned:
     description: "True/False value to indicate if no labels should be added or removed if there is an assignee to the issue."
     required: true
-  ignore-add-if-labeled:
-    description: "True/False value to indicate if no labels should be added if the issue already has labels. Has no effect on removing labels."
+  ignore-if-labeled:
+    description: "True/False value to indicate if no labels should be added or removed if the issue already has labels."
     required: false
 branding:
   icon: zap-off

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,11 @@ inputs:
     description: 'Labels to be removed from an issue, seperated by commas.'
     required: false
   ignore-if-assigned:
-    description: "True/False value to indicate if no labels should be added or removed if there is an asignee to the issue"
+    description: "True/False value to indicate if no labels should be added or removed if there is an assignee to the issue."
     required: true
+  ignore-add-if-labeled:
+    description: "True/False value to indicate if no labels should be added if the issue already has labels. Has no effect on removing labels."
+    required: false
 branding:
   icon: zap-off
   color: orange

--- a/label.js
+++ b/label.js
@@ -37,7 +37,7 @@ async function label() {
   }
 
   let labels = updatedIssueInformation.data.labels.map(label => label.name);
-  const skipAddingLabels = ignoreAddIfLabeled && labels;
+  const skipAddingLabels = ignoreAddIfLabeled && labels.length > 0;
   if (!skipAddingLabels) {
     for (let labelToAdd of labelsToAdd) {
       if (!labels.includes(labelToAdd)) {

--- a/label.js
+++ b/label.js
@@ -1,7 +1,7 @@
 const github = require("@actions/github");
 const core = require("@actions/core");
 
-let labelsToAdd = core
+const labelsToAdd = core
   .getInput("add-labels")
   .split(",")
   .map(x => x.trim());

--- a/label.js
+++ b/label.js
@@ -1,7 +1,7 @@
 const github = require("@actions/github");
 const core = require("@actions/core");
 
-const labelsToAdd = core
+let labelsToAdd = core
   .getInput("add-labels")
   .split(",")
   .map(x => x.trim());
@@ -37,12 +37,12 @@ async function label() {
   }
 
   let labels = updatedIssueInformation.data.labels.map(label => label.name);
-  const skipAddingLabels = ignoreAddIfLabeled && labels.length > 0;
-  if (!skipAddingLabels) {
-    for (let labelToAdd of labelsToAdd) {
-      if (!labels.includes(labelToAdd)) {
-        labels.push(labelToAdd);
-      }
+  if (ignoreAddIfLabeled && labels.length > 0) {
+    labelsToAdd = [];
+  }
+  for (let labelToAdd of labelsToAdd) {
+    if (!labels.includes(labelToAdd)) {
+      labels.push(labelToAdd);
     }
   }
   labels = labels.filter(value => {

--- a/label.js
+++ b/label.js
@@ -37,7 +37,8 @@ async function label() {
   }
 
   let labels = updatedIssueInformation.data.labels.map(label => label.name);
-  if (!ignoreAddIfLabeled) {
+  const skipAddingLabels = ignoreAddIfLabeled && labels;
+  if (!skipAddingLabels) {
     for (let labelToAdd of labelsToAdd) {
       if (!labels.includes(labelToAdd)) {
         labels.push(labelToAdd);

--- a/label.js
+++ b/label.js
@@ -14,6 +14,7 @@ const labelsToRemove = core
 async function label() {
   const myToken = core.getInput("repo-token");
   const ignoreIfAssigned = core.getInput("ignore-if-assigned");
+  const ignoreAddIfLabeled = core.getInput("ignore-add-if-labeled");
   const octokit = new github.GitHub(myToken);
   const context = github.context;
   const repoName = context.payload.repository.name;
@@ -30,15 +31,17 @@ async function label() {
 
   if (ignoreIfAssigned) {
     // check if the issue has been assigned to anyone
-    if (updatedIssueInformation.data.assignees.length != 0) {
+    if (updatedIssueInformation.data.assignees.length !== 0) {
       return "No action being taken. Ignoring because one or more assignees have been added to the issue";
     }
   }
 
   let labels = updatedIssueInformation.data.labels.map(label => label.name);
-  for (let labelToAdd of labelsToAdd) {
-    if (!labels.includes(labelToAdd)) {
-      labels.push(labelToAdd);
+  if (!ignoreAddIfLabeled) {
+    for (let labelToAdd of labelsToAdd) {
+      if (!labels.includes(labelToAdd)) {
+        labels.push(labelToAdd);
+      }
     }
   }
   labels = labels.filter(value => {

--- a/label.js
+++ b/label.js
@@ -14,7 +14,7 @@ const labelsToRemove = core
 async function label() {
   const myToken = core.getInput("repo-token");
   const ignoreIfAssigned = core.getInput("ignore-if-assigned");
-  const ignoreAddIfLabeled = core.getInput("ignore-add-if-labeled");
+  const ignoreIfLabeled = core.getInput("ignore-if-labeled");
   const octokit = new github.GitHub(myToken);
   const context = github.context;
   const repoName = context.payload.repository.name;
@@ -37,9 +37,12 @@ async function label() {
   }
 
   let labels = updatedIssueInformation.data.labels.map(label => label.name);
-  if (ignoreAddIfLabeled && labels.length > 0) {
-    labelsToAdd = [];
+  if (ignoreIfLabeled) {
+    if (labels.length !== 0) {
+      return "No action being taken. Ignoring because one or labels have been added to the issue";
+    }
   }
+
   for (let labelToAdd of labelsToAdd) {
     if (!labels.includes(labelToAdd)) {
       labels.push(labelToAdd);


### PR DESCRIPTION
Where we use this, we have the action add a "needs triage" label to all new issues.  Often, we already know how an issue should be triaged when we open it, so the labeling by the bot is redundant and just has to be removed.

This is adding an input similar to `ignore-if-assigned` to ignore if an issued is labeled.

**Testing**
https://github.com/brcrista/labeler-test/issues