### PR TITLE
Project card event added support & input labels list guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: initial labeling
-        uses: andymckay/labeler@1.0.2
+        uses: andymckay/labeler@master
         with:
           repo-token: ${{secrets.GH_TOKEN}}
           add-labels: "needs-triage, bug"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# Intro
 Automatically adds or removes labels from issues. You define the labels you'd like to add and/or remove in the YAML file. You can also specify if an issue should be ignored if an assignee has been added.
 
 To add it to your workflow:
@@ -37,3 +38,8 @@ on:
   issues:
     types: [assigned]
 ```
+
+# Supported Github events
+- 'issues'
+- 'pull_request'
+- 'project_card'

--- a/README.md
+++ b/README.md
@@ -1,45 +1,100 @@
 # Intro
 Automatically adds or removes labels from issues. You define the labels you'd like to add and/or remove in the YAML file. You can also specify if an issue should be ignored if an assignee has been added.
 
-To add it to your workflow:
+
+## Supported Github events
+- 'issues'
+- 'pull_request'
+- 'project_card'
+
+
+## Examples
+
+### labels
+`add-labels` and `remove-labels` may receive multiple labels separated by commas.
 
 ```yml
-    - uses: andymckay/labeler@1.0.2
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        add-labels: "needs-triage, bug"
-        ignore-if-assigned: true
+add-labels: 'label1, label2'
+remove-labels: 'label1, label2'
 ```
 
-This adds the `needs-triage` and `bug` labels to the issue. The most common approach is to do this when issues are created, you can do this with the following in your workflow file:
+### Events, add-labels & remove-labels
 
 ```yml
+name: issue-automation
+
 on:
   issues:
     types: [opened]
+  pull_request:
+    types: [opened]
+  project_card:
+    types: [moved]
+
+jobs:
+  automate-issues-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: initial labeling
+        uses: andymckay/labeler@1.0.2
+        with:
+          repo-token: ${{secrets.GH_TOKEN}}
+          add-labels: "needs-triage, bug"
+          remove-labels: "in progress"
+
 ```
+
+This runs on 3 types of events:
+- `issues` creation
+- `pull_request` creation
+- `project_card` move
+
+This adds the labels `needs-triage` and `bug` and removes the label `in progress`.
+
+### ignore-if-assigned
 
 The parameter `ignore-if-assigned` checks at the time of the action running if the issue has been assigned to anyone. If set to `True` and the issue is assigned to anyone, then no labels will be added or removed. This can be helpful for new issues that immediatly get labels or assignees and don't require any action to be taken.
-
-This action can also be used to remove labels from an issue. Just pass the label(s) to be removed separated by commas.
-
-```yml
-    - uses: andymckay/labeler@1.0.2
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        remove-labels: "help-wanted"
-        ignore-if-assigned: false
-```
 
 An example use-case would be, to remove the `help-wanted` label when an issue is assigned to someone. For this, the workflow file would look like:
 
 ```yml
+name: issue-automation
+
 on:
   issues:
     types: [assigned]
+
+jobs:
+  automate-issues-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: andymckay/labeler@1.0.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          remove-labels: "help-wanted"
+          ignore-if-assigned: false
 ```
 
-# Supported Github events
-- 'issues'
-- 'pull_request'
-- 'project_card'
+### ignore-if-labeled
+
+The parameter `ignore-if-labeled` checks at the time of the action running if the issue has been labeled. If set to `True` and the issue is labeled, then no labels will be added or removed. This can be helpful for new issues that immediatly get labels or assignees and don't require any action to be taken.
+
+An example use-case would be, to add the `needs-triage` label when an issue is oppened without labels. For this, the workflow file would look like:
+
+```yml
+name: issue-automation
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  automate-issues-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: andymckay/labeler@1.0.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          add-labels: "needs-triage"
+          ignore-if-labeled: true
+```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ remove-labels: 'label1, label2'
 ```
 
 ### Events, add-labels & remove-labels
+`add-labels` and `remove-labels` may be used together. 
 
 ```yml
 name: issue-automation
@@ -49,7 +50,11 @@ This runs on 3 types of events:
 - `pull_request` creation
 - `project_card` move
 
-This adds the labels `needs-triage` and `bug` and removes the label `in progress`.
+This adds the labels:
+- `needs-triage`
+- `bug` 
+
+And removes the label `in progress`.
 
 ### ignore-if-assigned
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# Intro
-Automatically adds or removes labels from issues. You define the labels you'd like to add and/or remove in the YAML file. You can also specify if an issue should be ignored if an assignee has been added.
+Automatically adds or removes labels from issues, pull requests and project cards.
 
 
 ## Supported Github events
@@ -7,19 +6,24 @@ Automatically adds or removes labels from issues. You define the labels you'd li
 - 'pull_request'
 - 'project_card'
 
+## repo-token
+Some github access token is needed since this action uses the github api. See the (oficial documentation)[https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line] for more info.
 
-## Examples
 
-### labels
-`add-labels` and `remove-labels` may receive multiple labels separated by commas.
+## add-labels & remove-labels
+to add or remove labels the parameters are:
+- `add-labels`
+- `remove-labels` 
+
+They may receive multiple labels separated by commas.
+They also may be used together. 
 
 ```yml
 add-labels: 'label1, label2'
 remove-labels: 'label1, label2'
 ```
 
-### Events, add-labels & remove-labels
-`add-labels` and `remove-labels` may be used together. 
+## Complete 'basic' usage
 
 ```yml
 name: issue-automation
@@ -56,7 +60,7 @@ This adds the labels:
 
 And removes the label `in progress`.
 
-### ignore-if-assigned
+## ignore-if-assigned
 
 The parameter `ignore-if-assigned` checks at the time of the action running if the issue has been assigned to anyone. If set to `True` and the issue is assigned to anyone, then no labels will be added or removed. This can be helpful for new issues that immediatly get labels or assignees and don't require any action to be taken.
 
@@ -80,7 +84,7 @@ jobs:
           ignore-if-assigned: false
 ```
 
-### ignore-if-labeled
+## ignore-if-labeled
 
 The parameter `ignore-if-labeled` checks at the time of the action running if the issue has been labeled. If set to `True` and the issue is labeled, then no labels will be added or removed. This can be helpful for new issues that immediatly get labels or assignees and don't require any action to be taken.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ They also may be used together.
 
 ```yml
 add-labels: 'label1, label2'
-remove-labels: 'label1, label2'
+remove-labels: 'label3, label4'
 ```
 
 ## Complete 'basic' usage

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ jobs:
   automate-issues-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: andymckay/labeler@1.0.2
+      - uses: andymckay/labeler@master
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           remove-labels: "help-wanted"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Automatically adds or removes labels from issues, pull requests and project card
 - 'project_card'
 
 ## repo-token
-Some github access token is needed since this action uses the github api. See the (oficial documentation)[https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line] for more info.
+Some github access token is needed since this action uses the github api. See the [oficial documentation](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) for more info.
 
 
 ## add-labels & remove-labels

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Automatically adds or removes labels from issues, pull requests and project card
 - 'project_card'
 
 ## repo-token
-Some github access token is needed since this action uses the github api. See the [oficial documentation](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) for more info.
+To use this action a github access token is required since the github api is used. See the [oficial documentation](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) for more info.
 
 
 ## add-labels & remove-labels

--- a/label.js
+++ b/label.js
@@ -23,14 +23,14 @@ async function label() {
 
   if (context.payload.issue !== undefined) {
     issueNumber = context.payload.issue.number;
-  } 
+  }
   else if (context.payload.pull_request !== undefined) {
     issueNumber = context.payload.pull_request.number;
   }
   else if (context.payload.project_card !== undefined) {
     var issuesUrl = context.payload.project_card.issues_url;
     var urlArray = issuesUrl.split("/");
-    issueNumber = urlArray[urlArray.length-1];
+    issueNumber = urlArray[urlArray.length - 1];
     if (issueNumber == "issues") {
       issueNumber = undefined;
     }

--- a/label.js
+++ b/label.js
@@ -28,11 +28,11 @@ async function label() {
     issueNumber = context.payload.pull_request.number;
   }
   else if (context.payload.project_card !== undefined) {
-    issuesUrl = context.payload.project_card.issues_url;
-    urlArray = issuesUrl.split('/');
+    var issuesUrl = context.payload.project_card.issues_url;
+    var urlArray = issuesUrl.split("/");
     issueNumber = urlArray[urlArray.length-1];
-    if (issueNumber == 'issues'){
-      issueNumber = undefined
+    if (issueNumber == "issues") {
+      issueNumber = undefined;
     }
   }
 

--- a/label.js
+++ b/label.js
@@ -25,7 +25,10 @@ async function label() {
     issueNumber = context.payload.issue.number;
   } else if (context.payload.pull_request !== undefined) {
     issueNumber = context.payload.pull_request.number;
-  } else if (context.payload.project_card !== undefined && context.payload.project_card.content_url) {
+  } else if (
+    context.payload.project_card !== undefined &&
+    context.payload.project_card.content_url
+  ) {
     issueNumber = context.payload.project_card.content_url.split("/").pop();
   }
 

--- a/label.js
+++ b/label.js
@@ -36,9 +36,9 @@ async function label() {
     return "No action being taken. Ignoring because issueNumber was not identified";
   }
 
-  labelsToAdd = labelsToAdd.filter(value => ![''].includes(value))
+  labelsToAdd = labelsToAdd.filter(value => ![""].includes(value));
 
-  labelsToRemove = labelsToRemove.filter(value => ![''].includes(value))
+  labelsToRemove = labelsToRemove.filter(value => ![""].includes(value));
 
   // query for the most recent information about the issue. Between the issue being created and
   // the action running, labels or asignees could have been added

--- a/label.js
+++ b/label.js
@@ -1,12 +1,12 @@
 const github = require("@actions/github");
 const core = require("@actions/core");
 
-const labelsToAdd = core
+var labelsToAdd = core
   .getInput("add-labels")
   .split(",")
   .map(x => x.trim());
 
-const labelsToRemove = core
+var labelsToRemove = core
   .getInput("remove-labels")
   .split(",")
   .map(x => x.trim());
@@ -36,6 +36,10 @@ async function label() {
     return "No action being taken. Ignoring because issueNumber was not identified";
   }
 
+  labelsToAdd = labelsToAdd.filter(value => ![''].includes(value))
+
+  labelsToRemove = labelsToRemove.filter(value => ![''].includes(value))
+
   // query for the most recent information about the issue. Between the issue being created and
   // the action running, labels or asignees could have been added
   var updatedIssueInformation = await octokit.issues.get({
@@ -63,9 +67,8 @@ async function label() {
       labels.push(labelToAdd);
     }
   }
-  labels = labels.filter(value => {
-    return !labelsToRemove.includes(value);
-  });
+
+  labels = labels.filter(value => !labelsToRemove.includes(value));
 
   await octokit.issues.update({
     owner: ownerName,

--- a/label.js
+++ b/label.js
@@ -25,11 +25,12 @@ async function label() {
     issueNumber = context.payload.issue.number;
   } else if (context.payload.pull_request !== undefined) {
     issueNumber = context.payload.pull_request.number;
-  } else if (context.payload.project_card !== undefined) {
-    issueNumber = context.payload.project_card.issues_url.split("/").pop()
-    if (issueNumber == "issues") {
-      issueNumber = undefined;
-    }
+  } else if (context.payload.project_card !== undefined && context.payload.project_card.content_url) {
+    issueNumber = context.payload.project_card.content_url.split("/").pop();
+  }
+
+  if (issueNumber === undefined) {
+    return "No action being taken. Ignoring because issueNumber was not identified";
   }
 
   // query for the most recent information about the issue. Between the issue being created and

--- a/label.js
+++ b/label.js
@@ -23,8 +23,17 @@ async function label() {
 
   if (context.payload.issue !== undefined) {
     issueNumber = context.payload.issue.number;
-  } else {
+  } 
+  else if (context.payload.pull_request !== undefined) {
     issueNumber = context.payload.pull_request.number;
+  }
+  else if (context.payload.project_card !== undefined) {
+    issuesUrl = context.payload.project_card.issues_url;
+    urlArray = issuesUrl.split('/');
+    issueNumber = urlArray[urlArray.length-1];
+    if (issueNumber == 'issues'){
+      issueNumber = undefined
+    }
   }
 
   // query for the most recent information about the issue. Between the issue being created and

--- a/label.js
+++ b/label.js
@@ -26,9 +26,7 @@ async function label() {
   } else if (context.payload.pull_request !== undefined) {
     issueNumber = context.payload.pull_request.number;
   } else if (context.payload.project_card !== undefined) {
-    var issuesUrl = context.payload.project_card.issues_url;
-    var urlArray = issuesUrl.split("/");
-    issueNumber = urlArray[urlArray.length - 1];
+    issueNumber = context.payload.project_card.issues_url.split("/").pop()
     if (issueNumber == "issues") {
       issueNumber = undefined;
     }

--- a/label.js
+++ b/label.js
@@ -23,11 +23,9 @@ async function label() {
 
   if (context.payload.issue !== undefined) {
     issueNumber = context.payload.issue.number;
-  }
-  else if (context.payload.pull_request !== undefined) {
+  } else if (context.payload.pull_request !== undefined) {
     issueNumber = context.payload.pull_request.number;
-  }
-  else if (context.payload.project_card !== undefined) {
+  } else if (context.payload.project_card !== undefined) {
     var issuesUrl = context.payload.project_card.issues_url;
     var urlArray = issuesUrl.split("/");
     issueNumber = urlArray[urlArray.length - 1];


### PR DESCRIPTION
I made my PR based on #11. I recommend to wait for the PR #11 to be merged to be sure there's no conflict.

Uses `context.payload.project_card.issues` to get the `issueNumber` from url if `context.payload.issue.number` and `context.payload.pull_request` are undefined.

This should fix #12.
this should fix #10.