### PR TITLE
Prevent labels when author is a team member

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   ignore-if-labeled:
     description: "True/False value to indicate if no labels should be added or removed if the issue already has labels."
     required: false
+  team: 
+    description: "Only label issues and pull requests by external contributors. If the author is a team member, the action ignores pull requests and issues that are opened. Use the org and team slug. For example, `octo-org/octokittens`."
+    required: false
 branding:
   icon: zap-off
   color: orange

--- a/label.js
+++ b/label.js
@@ -35,7 +35,7 @@ async function label() {
     issue_number: issueNumber
   });
 
-  if (team) {
+  if (team && context.eventName === "pull_request") {
     const teamArr = team.split("/");
     const org = teamArr.shift();
     const teamSlug = teamArr.pop();

--- a/label.js
+++ b/label.js
@@ -60,19 +60,17 @@ async function label() {
   let labels = updatedIssueInformation.data.labels.map(label => label.name);
   if (ignoreIfLabeled) {
     if (labels.length !== 0) {
-      return "No action being taken. Ignoring because one or labels have been added to the issue";
+      return "No action being taken. Ignoring because one or more labels have been added to the issue";
     }
   }
 
   for (let labelToAdd of labelsToAdd) {
-    if (!labels.includes(labelToAdd)) {
+    if (!labels.includes(labelToAdd) && labelToAdd !== "") {
       labels.push(labelToAdd);
     }
   }
-  labels = labels.filter(value => {
-    return !labelsToRemove.includes(value);
-  });
 
+  labels = labels.filter(value => !labelsToRemove.includes(value));
   await octokit.issues.update({
     owner: ownerName,
     repo: repoName,

--- a/label.js
+++ b/label.js
@@ -19,15 +19,36 @@ async function label() {
   const context = github.context;
   const repoName = context.payload.repository.name;
   const ownerName = context.payload.repository.owner.login;
-  const issueNumber = context.payload.issue.number;
+  let issueNumber;
+  if (context.eventName === "issues") {
+    issueNumber = context.payload.issue.number;
+  } else {
+    issueNumber = context.payload.number;
+  }
+  const team = core.getInput("team");
 
   // query for the most recent information about the issue. Between the issue being created and
   // the action running, labels or asignees could have been added
-  var updatedIssueInformation = await octokit.issues.get({
+  const updatedIssueInformation = await octokit.issues.get({
     owner: ownerName,
     repo: repoName,
     issue_number: issueNumber
   });
+
+  if (team) {
+    const teamArr = team.split("/");
+    const org = teamArr.shift();
+    const teamSlug = teamArr.pop();
+    const teamMembers = await octokit.request(
+      `/orgs/${org}/teams/${teamSlug}/members`
+    );
+    const logins = teamMembers.data.map(member => member.login);
+    for (let login of logins) {
+      if (login === updatedIssueInformation.data.user.login) {
+        return `No action being taken. Ignoring because the author of the issue or pull request is part of the ${team} team`;
+      }
+    }
+  }
 
   if (ignoreIfAssigned) {
     // check if the issue has been assigned to anyone

--- a/label.js
+++ b/label.js
@@ -35,7 +35,7 @@ async function label() {
     issue_number: issueNumber
   });
 
-  if (team && context.eventName === "pull_request") {
+  if (team) {
     const teamArr = team.split("/");
     const org = teamArr.shift();
     const teamSlug = teamArr.pop();
@@ -79,7 +79,7 @@ async function label() {
     issue_number: issueNumber,
     labels: labels
   });
-  return `Updated labels in ${context.payload.issue.number}. Added: ${labelsToAdd}. Removed: ${labelsToRemove}.`;
+  return `Updated labels in ${issueNumber}. Added: ${labelsToAdd}. Removed: ${labelsToRemove}.`;
 }
 
 label()


### PR DESCRIPTION
This update allows both issues and pull requests to be labeled. It also adds a new input parameter to prevent the label from being added when the author of a pull request is a member of the team. This update allows us to catch all external collaborator PRs opened to ensure they get a timely review.

Initially, I was preventing both issues and pull requests from being labeled when a team member was the author. But there might be a case when team member opens the issue but expects the first responder to triage it to the correct project board. I'm curious how other teams might use this feature to first respond. I could also make labeling issues and PRs configurable when the author is a team member.