### PR TITLE
Remove github-token requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ Automatically adds or removes labels from issues, pull requests and project card
 
 
 ## Supported Github events
-- 'issues'
-- 'pull_request'
-- 'project_card'
+- `issues`
+- `pull_request`
+- `project_card`
 
 ## add-labels & remove-labels
 to add or remove labels the parameters are:

--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@ Automatically adds or removes labels from issues, pull requests and project card
 - 'pull_request'
 - 'project_card'
 
-## repo-token
-To use this action a github access token is required since the github api is used. See the [oficial documentation](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) for more info.
-
-
 ## add-labels & remove-labels
 to add or remove labels the parameters are:
 - `add-labels`
@@ -43,7 +39,6 @@ jobs:
       - name: initial labeling
         uses: andymckay/labeler@master
         with:
-          repo-token: ${{secrets.GH_TOKEN}}
           add-labels: "needs-triage, bug"
           remove-labels: "in progress"
 
@@ -79,7 +74,6 @@ jobs:
     steps:
       - uses: andymckay/labeler@master
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
           remove-labels: "help-wanted"
           ignore-if-assigned: false
 ```
@@ -103,7 +97,6 @@ jobs:
     steps:
       - uses: andymckay/labeler@1.0.2
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
           add-labels: "needs-triage"
           ignore-if-labeled: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -2,8 +2,9 @@ name: 'Simple Issue Labeler'
 description: 'Adds and removes labels from issues.'
 inputs:
   repo-token:
-    description: 'Token for the repo. Can be passed in using {{ secrets.GITHUB_TOKEN }}'
-    required: true
+    description: 'The GitHub token'
+    required: false
+    default: ${{ github.token }}
   add-labels:
     description: 'Labels to add to an issue, seperated by commas.'
     required: false


### PR DESCRIPTION
This makes `repo-token` optional and provides a default value in the `action.yml` by doing that, you don't need to actually provide it in your Workflow file and it saves you a bit of time.