### PR TITLE
Add (optional) parameter to override issue/pr number

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Automatically adds or removes labels from issues, pull requests and project card
 - `issues`
 - `pull_request`
 - `project_card`
-- If you manually specificy the issue/pull request number then it can be used in other event types
+- If you manually specify the issue/pull request number then it can be used in other event types
 
 ## add-labels & remove-labels
 to add or remove labels the parameters are:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Automatically adds or removes labels from issues, pull requests and project card
 - `issues`
 - `pull_request`
 - `project_card`
+- If you manually specificy the issue/pull request number then it can be used in other event types
 
 ## add-labels & remove-labels
 to add or remove labels the parameters are:
@@ -99,4 +100,33 @@ jobs:
         with:
           add-labels: "needs-triage"
           ignore-if-labeled: true
+```
+
+## Override issue/pull request number
+
+If you specify the `number` parameter, then the issue/pull request number is override and not automatically determined by the event type. This allows you to use the action in other events.
+
+```yml
+name: issue-automation
+
+on:
+  workflow_dispatch:
+    inputs:
+      number:
+        description: 'Issue or pull request number'     
+        required: true
+      addLabels:
+        description: 'Labels to add'        
+      removeLabels:
+        description: 'Labels to remove'        
+
+jobs:
+  manuall-assign-issues-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: initial labeling
+        uses: andymckay/labeler@master
+        with:
+          add-labels: "${{ github.event.inputs.addLabels }}"
+          remove-labels: "${{ github.event.inputs.removeLabels }}"
 ```

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   ignore-if-labeled:
     description: "True/False value to indicate if no labels should be added or removed if the issue already has labels."
     required: false
+  number:
+    description: "Force a given issue/pull-request number"
+    required: false
 branding:
   icon: zap-off
   color: orange

--- a/label.js
+++ b/label.js
@@ -15,13 +15,17 @@ async function label() {
   const myToken = core.getInput("repo-token");
   const ignoreIfAssigned = core.getInput("ignore-if-assigned");
   const ignoreIfLabeled = core.getInput("ignore-if-labeled");
+  const overrideNumber = core.getInput("number");
   const octokit = new github.GitHub(myToken);
   const context = github.context;
   const repoName = context.payload.repository.name;
   const ownerName = context.payload.repository.owner.login;
+  
   var issueNumber;
 
-  if (context.payload.issue !== undefined) {
+  if (overrideNumber !== "") {
+    issueNumber = overrideNumber
+  } else if (context.payload.issue !== undefined) {
     issueNumber = context.payload.issue.number;
   } else if (context.payload.pull_request !== undefined) {
     issueNumber = context.payload.pull_request.number;


### PR DESCRIPTION
By allowing workflows to override the issue/pr number instead of relying on the event type the action can be used with any other event type 