### PR TITLE
Ability to accept issue number as parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   ignore-if-labeled:
     description: "True/False value to indicate if no labels should be added or removed if the issue already has labels."
     required: false
+  issue-number:
+    description: "An issue number or PR number or project card number. Optional, if not specified, will use the one available in github event `github.event.pull_request` or `github.event.issue`"
+    required: false
 branding:
   icon: zap-off
   color: orange


### PR DESCRIPTION
**Context:**

In cases of dispatch event-triggered workflows, issue numbers will not be available in the context.  This PR adds `issue-number` parameter, which supersedes what gets derived from context. 

**Testing**
I tested these changes for "issue" triggered workflow and also on a custom event dispatch workflow. 
