### PR TITLE
Fix a property reference of pull_request.number

### DIFF
--- a/label.js
+++ b/label.js
@@ -29,7 +29,7 @@ function getIssueNumber(core, context) {
 
   // return the one found in PR
   issueNumber =
-    context.payload.pull_request && context.payload.issue.pull_request;
+    context.payload.pull_request && context.payload.pull_request.number;
   if (issueNumber) return issueNumber;
 
   let card_url =


### PR DESCRIPTION
Hi.
I saw an error when i triggered a workflow on pull request, such below:

    TypeError: Cannot read property 'pull_request' of undefined
    at getIssueNumber (/home/runner/work/_actions/andymckay/labeler/1.0.3/label.js:32:59)

I fixed this and tested it works fine.
https://github.com/upinetree/actions_sandbox/pull/7