### PR TITLE
Use addLabels instead of update function if we are not removing any label

### DIFF
--- a/label.js
+++ b/label.js
@@ -85,14 +85,22 @@ async function label() {
     }
   }
 
-  labels = labels.filter(value => !labelsToRemove.includes(value));
-
-  await octokit.issues.update({
-    owner: ownerName,
-    repo: repoName,
-    issue_number: issueNumber,
-    labels: labels
-  });
+  if (labelsToRemove.length != 0) {
+    labels = labels.filter(value => !labelsToRemove.includes(value));
+    await octokit.issues.update({
+      owner: ownerName,
+      repo: repoName,
+      issue_number: issueNumber,
+      labels: labels
+    });
+  } else {
+    await octokit.issues.addLabels({
+      owner: ownerName,
+      repo: repoName,
+      issue_number: issueNumber,
+      labels: labels
+    });
+  }
   return `Updated labels in ${issueNumber}. Added: ${labelsToAdd}. Removed: ${labelsToRemove}.`;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labeler",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Labels issues when they land in a repo.",
   "main": "label.js",
   "scripts": {


### PR DESCRIPTION
### Description of the change

Use `addLabels` function instead of updating the whole list of labels when no remove is required.

### Benefits

This change avoids possible issues about cache or concurrency

### Possible drawbacks

None identified

## Applicable issues
 - fixes #40 
